### PR TITLE
#16 Implement return to specific dashboard after submitting successfully

### DIFF
--- a/client/src/components/attendance/AttendanceForm.js
+++ b/client/src/components/attendance/AttendanceForm.js
@@ -230,7 +230,10 @@ export default function AttendanceForm(props) {
         setSubmitSuccessful(submitSuccessful + 1);
         setPromptMessage('Successfully submitted attendance form!');
 
-        setTimeout(() => setPromptMessage(''), 3000);
+        setTimeout(() => {
+          setPromptMessage('');
+          history.replace('/events');
+        }, 1500);
       }
     });
   };

--- a/client/src/components/event/EventForm.js
+++ b/client/src/components/event/EventForm.js
@@ -22,14 +22,13 @@ const useStyles = makeStyles((theme) => ({
 
 export default function EventForm(props) {
   const classes = useStyles();
+  const history = useHistory();
 
   const eventTypes = [
     'Meeting',
     'Training',
     'Project',
   ];
-
-  const history = useHistory();
 
   const [isNew, setIsNew] = useState(true);
 

--- a/client/src/components/event/EventForm.js
+++ b/client/src/components/event/EventForm.js
@@ -102,7 +102,10 @@ export default function EventForm(props) {
         } else {
           setSubmitSuccessful(1);
           setPromptMessage('Successfully edited an existing event!');
-          setTimeout(() => setPromptMessage(''), 3000);
+          setTimeout(() => {
+            setPromptMessage('');
+            history.replace('/events');
+          }, 1500);
         }
       });
     } else {

--- a/client/src/components/member/MemberForm.js
+++ b/client/src/components/member/MemberForm.js
@@ -24,6 +24,7 @@ const useStyles = makeStyles((theme) => ({
 
 export default function MemberForm(props) {
   const classes = useStyles();
+  const history = useHistory();
 
   const [isNew, setIsNew] = useState(props.memberId !== undefined);
 
@@ -36,8 +37,6 @@ export default function MemberForm(props) {
 
   const [submitSuccessful, setSubmitSuccessful] = useState(null);
   const [promptMessage, setPromptMessage] = useState('');
-
-  const history = useHistory();
 
   useEffect(() => {
     if (props.memberId) {
@@ -94,7 +93,7 @@ export default function MemberForm(props) {
         setTimeout(() => {
           setPromptMessage('');
           history.replace('/members');
-        }, 3000);
+        }, 1500);
       } else {
         setSubmitSuccessful(1);
         setPromptMessage(`Successfully edited current member: ${memberName}`);

--- a/client/src/components/member/MemberForm.js
+++ b/client/src/components/member/MemberForm.js
@@ -3,6 +3,7 @@ import {
   Checkbox, FormControlLabel, Grid, makeStyles, TextField,
 } from '@material-ui/core';
 
+import { useHistory } from 'react-router-dom';
 import FormPaper from '../FormPaper';
 import { getDateFromDisplay, getDisplayDate } from '../../utils/DateTimeUtils';
 
@@ -35,6 +36,8 @@ export default function MemberForm(props) {
 
   const [submitSuccessful, setSubmitSuccessful] = useState(null);
   const [promptMessage, setPromptMessage] = useState('');
+
+  const history = useHistory();
 
   useEffect(() => {
     if (props.memberId) {
@@ -88,11 +91,17 @@ export default function MemberForm(props) {
       } else if (isNew) {
         setSubmitSuccessful(1);
         setPromptMessage(`Successfully added new member: ${memberName}`);
-        setTimeout(() => setPromptMessage(''), 3000);
+        setTimeout(() => {
+          setPromptMessage('');
+          history.replace('/members');
+        }, 3000);
       } else {
         setSubmitSuccessful(1);
         setPromptMessage(`Successfully edited current member: ${memberName}`);
-        setTimeout(() => setPromptMessage(''), 3000);
+        setTimeout(() => {
+          setPromptMessage('');
+          history.replace('/members');
+        }, 1500);
       }
     });
   };


### PR DESCRIPTION
Using useHistory() hook, after submit successfully redirected to either events or members dashboard depending on the submit form (either add/edit event or member).

Closes #16 